### PR TITLE
JDP220502-35: OrderController, OrderDto - zmiana Date na LocalDate + …

### DIFF
--- a/src/main/java/com/kodilla/ecommercee/controller/OrderController.java
+++ b/src/main/java/com/kodilla/ecommercee/controller/OrderController.java
@@ -6,6 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -17,13 +18,13 @@ import java.util.List;
 public class OrderController {
 
     @GetMapping
-    public List<OrderDto> getOrder() {
+    public List<OrderDto> getOrders() {
         return new ArrayList<>();
     }
 
     @GetMapping(value = "{orderId}")
     public OrderDto getOrder(@PathVariable long orderId) {
-        return new OrderDto(1,1,"order status",new Date(2000,11, 11));
+        return new OrderDto(1,1,"order status", LocalDate.of(2000, 11, 11));
     }
     @DeleteMapping(value = "{orderId}")
     public String deleteOrder(@PathVariable long orderId) {
@@ -32,13 +33,13 @@ public class OrderController {
 
     @PutMapping
     public OrderDto updateOrder(@RequestBody OrderDto orderDto){
-        return new OrderDto(1,1,"order status ",new Date(2000,11, 13));
+        return new OrderDto(1,1,"order status ", LocalDate.of(2010, 10, 20));
     }
 
     @PostMapping
     public OrderDto createOrder(@RequestBody OrderDto orderDto){
 
-        return new OrderDto(2, 2,"create order" , new Date( 2111,11,10));
+        return new OrderDto(2, 2,"create order" , LocalDate.of(2111, 9, 11));
     }
 
 

--- a/src/main/java/com/kodilla/ecommercee/domain/OrderDto.java
+++ b/src/main/java/com/kodilla/ecommercee/domain/OrderDto.java
@@ -3,7 +3,7 @@ package com.kodilla.ecommercee.domain;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-import java.util.Date;
+import java.time.LocalDate;
 
 @Getter
 @AllArgsConstructor
@@ -11,7 +11,7 @@ public class OrderDto {
     private long order_id;
     private long cart_id;
     private String status;
-    private Date order_date;
+    private LocalDate order_date;
 
 
 }


### PR DESCRIPTION
Implementacja endpointów zawierała obiekt Date nieobsługiwany od Javy 8. Przy testach endpointów zwracane są nieprawidłowe daty.
Metody do endpointów Get miały tę samą nazwę zarówno dla metody pobierającej pojedyncze zadanie jak i dla listy zadań (zmieniona na getOrders()).